### PR TITLE
Clone chelsea

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -352,9 +352,6 @@ router.put('/verifytoken', async(req, res) => {
     .createHash(process.env.HASH)
     .update(req.body.verifyToken)
     .digest(process.env.DIGEST);
-
-    console.log("VerifyToken: " + req.body.verifyToken)
-    console.log("verificationToken: " + verificationToken)
     
     await User.findOne({resetPasswordToken: verificationToken}, async(err,user)=>{
         if(err){


### PR DESCRIPTION
-I fixed the code so that it no longer hang in the following situations:
 the wrong email is entered on login, the wrong password reset token it passed to the password reset endpoint, the wrong verification token is passed to the email verification endpoint.

-Added a new /users/verifytoken endpoint that allows email verification through a req.body, instead of a url. 

-Added the verify token to the success response of the /users/verify/{verifyToken} endpoint

-fixed the resend verification endpoint, though it's probably not even needed.

These are the only changes.  
All fixed/added endpoints were thoroughly tested using the Heroku server and are verified to be working.   
The changes are have also been documented in the API documentation.
